### PR TITLE
fix(.dependabot): remove bddckr from being default reviewer

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,7 +4,6 @@ update_configs:
     directory: /
     update_schedule: live
     default_reviewers:
-      - bddckr
       - thestonefox
     default_labels:
       - dependency-update


### PR DESCRIPTION
The dependabot default reviewer spams emails for every project
that is bumped so to save bddckr's sanity, his name has been
removed as a default reviewer.