### PR TITLE
feat(.gitignore): ignore obj.meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 [Ll]ibrary/
 [Tt]emp/
 [Oo]bj/
+[Oo]bj.meta
 [Bb]uild/
 [Bb]uilds/
 [Ll]ogs/


### PR DESCRIPTION
Sometimes a nested directory may have an auto generated `obj/`
directory but then Unity will create an obj.meta file which is
not wanted.